### PR TITLE
Add code-craft and ui-craft skills with related preferences

### DIFF
--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -27,6 +27,7 @@
     ${HOME}/.zshrc: src/zsh/.zshrc
     ${HOME}/.claude/CLAUDE.md: src/claude/CLAUDE.md
     ${HOME}/.claude/settings.json: src/claude/settings.json
+    ${HOME}/.claude/skills: src/claude/skills
     ${HOME}/.config/bat: src/bat
     ${HOME}/.config/ghostty/config: src/ghostty/config
     ${HOME}/.config/nvim: src/nvim

--- a/src/claude/CLAUDE.md
+++ b/src/claude/CLAUDE.md
@@ -34,6 +34,8 @@
   gitconfig, so don't add `-u origin <branch>`.
 - Make small, atomic commits: one logical change each, staging only the files
   that belong to it (add specific paths, not everything).
+- When a force-push is needed, use `git push --force-with-lease`, never
+  `--force`.
 
 ## Writing style
 

--- a/src/claude/CLAUDE.md
+++ b/src/claude/CLAUDE.md
@@ -32,6 +32,8 @@
 - Don't commit directly to `main` — create a branch first.
 - `git push` on its own is enough — upstream tracking is configured in the
   gitconfig, so don't add `-u origin <branch>`.
+- Make small, atomic commits: one logical change each, staging only the files
+  that belong to it (add specific paths, not everything).
 
 ## Writing style
 

--- a/src/claude/CLAUDE.md
+++ b/src/claude/CLAUDE.md
@@ -43,6 +43,9 @@
   that belong to it (add specific paths, not everything).
 - When a force-push is needed, use `git push --force-with-lease`, never
   `--force`.
+- Before pushing, check that the branch's commits are atomic and logically
+  ordered so they tell a clear story; if not, encourage the user to tidy the
+  history with an interactive rebase first.
 
 ## Security
 

--- a/src/claude/CLAUDE.md
+++ b/src/claude/CLAUDE.md
@@ -1,5 +1,10 @@
 # Preferences
 
+## Approach
+
+- Before implementing, read the surrounding code and its existing tests, and
+  follow the established patterns and style.
+
 ## Running commands
 
 - Don't suppress or truncate command output — no piping through `tail`, `head`,

--- a/src/claude/CLAUDE.md
+++ b/src/claude/CLAUDE.md
@@ -83,6 +83,7 @@
 - Write the body as complete sentences without omitting parts of speech
   (unlike the imperative commit subject). Prefer opening with a subject such
   as "This" over a verb.
+- Include a screenshot (or short recording) for user-facing UI changes.
 - No trailing full stops on body paragraphs.
 
 ## Keeping this file current

--- a/src/claude/CLAUDE.md
+++ b/src/claude/CLAUDE.md
@@ -4,6 +4,9 @@
 
 - Before implementing, read the surrounding code and its existing tests, and
   follow the established patterns and style.
+- When making a significant, novel, or hard-to-reverse technical or
+  architectural decision, consider recording it as an Architecture Decision
+  Record (ADR).
 
 ## Running commands
 

--- a/src/claude/CLAUDE.md
+++ b/src/claude/CLAUDE.md
@@ -71,6 +71,9 @@
 
 - Subject line: describe what changed, 50 characters or fewer, imperative mood
   (e.g. "Show error when converting with no file").
+- When a commit changes these preferences, phrase the subject so it reads as
+  an instruction to Claude (e.g. "Have Claude read code before implementing"),
+  not like project policy or a code change.
 - Body: wrap at 72 characters. Explain any useful extra detail and the reason
   for the change (the why), not just the what.
 - Write the body in the present tense describing the commit ("This guards

--- a/src/claude/CLAUDE.md
+++ b/src/claude/CLAUDE.md
@@ -23,6 +23,8 @@
   (e.g. `rspec spec/foo_spec.rb:16`, not `rspec -e "does a thing"`).
 - When fixing a bug, write the test first and confirm it fails for the right
   reason before implementing the fix.
+- Don't consider a task complete until the change is covered by tests and the
+  suite passes with no regressions. Keep each commit's test suite green.
 
 ## Git
 

--- a/src/claude/CLAUDE.md
+++ b/src/claude/CLAUDE.md
@@ -8,6 +8,13 @@
   architectural decision, consider recording it as an Architecture Decision
   Record (ADR).
 
+## Learning
+
+- Treat notable design and refactoring decisions as learning opportunities: name
+  the principle at work, explain the why briefly, and offer (without forcing) a
+  short learning exercise, engaging the `learning-opportunities` skill on that
+  specific principle. Skip for trivial changes.
+
 ## Running commands
 
 - Don't suppress or truncate command output — no piping through `tail`, `head`,

--- a/src/claude/CLAUDE.md
+++ b/src/claude/CLAUDE.md
@@ -55,6 +55,10 @@
 - Don't cite DHH (David Heinemeier Hansson) as an authority or good example
   when justifying a choice. Reach for other evidence: community practice,
   concrete tradeoffs, or other named practitioners.
+- Don't cite Robert C. Martin ("Uncle Bob") as an authority or good example.
+  Using a term like "SOLID" is fine; just attribute the principles to their
+  originators (e.g. Bertrand Meyer for Open/Closed, Barbara Liskov for
+  substitution) or argue from concrete tradeoffs rather than from him.
 
 ## Commit messages
 

--- a/src/claude/CLAUDE.md
+++ b/src/claude/CLAUDE.md
@@ -37,6 +37,12 @@
 - When a force-push is needed, use `git push --force-with-lease`, never
   `--force`.
 
+## Security
+
+- Check code you write or change against the OWASP Top Ten (injection, XSS,
+  broken access control, and so on) and flag anything you spot.
+- Never print, log, or commit secrets or credentials.
+
 ## Writing style
 
 - Don't use em dashes in commit messages, PR bodies, or plain-text content

--- a/src/claude/skills/code-craft/SKILL.md
+++ b/src/claude/skills/code-craft/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: code-craft
+description: >-
+  Apply the combined lens of Sandi Metz (OOP design), Martin Fowler
+  (refactoring and code smells), the Gang of Four (design patterns), general
+  engineering wisdom (The Pragmatic Programmer, Code Complete), and test design
+  (five-factor testing, the test pyramid) when reviewing, refactoring, deciding
+  how to structure code, or deciding how to test it. Use when reviewing code for
+  quality or maintainability, cleaning up code smells or technical debt,
+  refactoring existing code, weighing whether a design pattern fits a new
+  feature, judging whether a test earns its place or at what level to write it,
+  or when the user mentions Sandi Metz, POODR, 99 Bottles, Fowler, refactoring,
+  design patterns, Gang of Four, GoF, The Pragmatic Programmer, Code Complete,
+  SOLID, Liskov, Open/Closed, connascence, data modelling, performance,
+  idempotency, retries, reliability, test pyramid, or test design. Not for
+  UI/UX concerns (see the ui-craft skill).
+---
+
+# code-craft
+
+A single lens for improving code, drawing on four complementary sources.
+Reviewers and designers apply these together, not one at a time, so this skill
+unifies them and reconciles where they pull in different directions.
+
+## The one guardrail that reconciles them
+
+Prefer the simplest thing that works. Sandi Metz and Fowler push toward smaller,
+clearer, behaviour-preserving code; the Gang of Four offers structures that add
+indirection. These only conflict if you reach for a pattern speculatively.
+
+**Introduce a pattern, abstraction, or indirection only to remove a problem
+that exists now, never one you imagine might exist later.** When Fowler's smells
+and a GoF pattern disagree, the smell wins: remove duplication and coupling
+first; a pattern is justified only if it leaves the code simpler against a real,
+present need. This is Fowler's "economics, not aesthetics" and the Pragmatic
+Programmer's warning against speculative generality, in one rule. Put plainly:
+YAGNI (you aren't gonna need it) and KISS (keep it simple) - prefer the simplest
+thing that works until a concrete, present need proves otherwise.
+
+## Cite your sources
+
+When you apply advice from these sources, name the source so the reasoning is
+traceable and the user can push back.
+
+- **In responses**: attribute the idea as you give it - "Metz's rule: methods
+  under five lines", "this is Feature Envy (Fowler)", "the Strategy pattern
+  (GoF) fits here because...", "the Pragmatic Programmer's DRY".
+- **In commit messages**: where a change is driven by one of these sources and
+  naming it adds useful context, cite it in the body (not the subject) - for
+  example, "Extract the parameter object to remove Fowler's Long Parameter List
+  smell". Cite for context, not decoration; omit it when the diff speaks for
+  itself.
+
+## Learning mode
+
+The user treats design choices as learning opportunities, not just output. When
+you apply a named idea from the references (a smell, a refactoring, a pattern, a
+SOLID principle, connascence), name it and say briefly why it applies here. On a
+good teaching moment - a non-trivial refactor, a design or pattern decision, a
+new abstraction - offer (do not force) a short exercise, and engage the
+`learning-opportunities` skill on that specific principle rather than a generic
+prompt. Skip this for trivial or mechanical changes.
+
+## Three modes
+
+**Review** - read the code, name issues by their catalogue term (smell, rule
+violation) and cite the source, reference `file:line`, rank by impact, and say
+plainly when code is fine as-is. Do not invent problems to look thorough.
+
+**Refactor** - confirm tests exist and pass first. Apply changes in small,
+behaviour-preserving steps, running tests between them. Narrate each step. Never
+mix a refactor with a behaviour change in the same step.
+
+**Architect** - when structuring a new feature, start from the simplest design
+that satisfies the requirement. Reach for a pattern only when a concrete force
+(varying behaviour, many collaborators, a hard-to-test seam) makes it pay for
+itself. Name the pattern and the force it addresses.
+
+## Which reference to read when
+
+Read only what the task needs; each file is self-contained.
+
+| Situation | Read |
+|---|---|
+| Ruby OOP sizing, class/method design, dependencies, Law of Demeter | `references/object-oriented-design.md` |
+| Naming a code smell, choosing and safely applying a refactoring | `references/refactoring.md` |
+| Deciding whether a classic pattern fits a new design | `references/design-patterns.md` |
+| General construction quality, naming, defensiveness, decoupling | `references/general-principles.md` |
+| OOP design principles - SOLID, coupling, connascence, module depth, data modelling | `references/solid.md` |
+| Performance as a design concern - complexity, queries, caching | `references/performance.md` |
+| Reliability of services - idempotency, retries, timeouts, failure handling | `references/reliability.md` |
+| Whether a test earns its place, what to test, at what level | `references/testing.md` |
+
+Most real reviews touch more than one. A typical flow: spot smells with Fowler,
+size and shape objects with Metz, and only then ask whether a GoF pattern earns
+its keep, checking the whole against the general principles.
+
+## Language note
+
+Metz's rules are Ruby-specific in their numbers but their intent (small,
+single-responsibility, loosely-coupled objects) is general. Fowler, GoF, and the
+general principles are language-agnostic. Adapt idioms to the language in front
+of you.

--- a/src/claude/skills/code-craft/references/design-patterns.md
+++ b/src/claude/skills/code-craft/references/design-patterns.md
@@ -1,0 +1,96 @@
+# Gang of Four: design patterns
+
+From *Design Patterns: Elements of Reusable Object-Oriented Software* (Gamma,
+Helm, Johnson, Vlissides). Patterns are a shared vocabulary for recurring design
+problems, not a checklist to satisfy.
+
+## Read this before reaching for a pattern
+
+- A pattern is a response to a **force** that exists now: behaviour that varies,
+  a dependency you must invert, a construction that is getting complex, a graph
+  you must traverse uniformly. No force, no pattern.
+- Patterns add indirection. Indirection is a cost paid for flexibility. Only buy
+  flexibility you need. Forcing a pattern is Fowler's Speculative Generality and
+  the Pragmatic Programmer's over-engineering.
+- The book's two maxims are still the best summary: **"program to an interface,
+  not an implementation"** and **"favour object composition over class
+  inheritance"**.
+- Many patterns are lighter in dynamic languages. In Ruby, blocks/procs replace
+  much of Strategy, Command, and Template Method; duck typing removes the need
+  for explicit abstract types. Reach for the intent, not the C++/Java ceremony.
+
+## The 23 patterns by intent
+
+### Creational - how objects get made
+
+- **Factory Method** - defer which class to instantiate to a subclass/override.
+  Force: a class can't anticipate the concrete type it must create.
+- **Abstract Factory** - create families of related objects without naming
+  concretes. Force: the product set must swap as a group (e.g. per platform).
+- **Builder** - assemble a complex object step by step. Force: many optional
+  parts, or the same construction should yield different representations. Cures
+  Long Parameter List in constructors.
+- **Prototype** - create by cloning an existing instance. Force: instantiation
+  is expensive or configured at runtime.
+- **Singleton** - one instance, global access. Use sparingly; it is global
+  state and hurts testability. Often a smell in disguise.
+
+### Structural - how objects are composed
+
+- **Adapter** - make an incompatible interface fit an expected one. Force:
+  reusing a class whose interface you cannot change.
+- **Decorator** - add responsibilities to an object dynamically by wrapping.
+  Force: optional, combinable behaviours without a subclass explosion.
+- **Facade** - one simple interface over a complex subsystem. Force: callers
+  drowning in a subsystem's detail. Pairs with Metz's thin-controller aim.
+- **Composite** - treat individual objects and compositions uniformly. Force: a
+  part-whole tree the client should walk without special-casing leaves.
+- **Proxy** - a stand-in controlling access (lazy load, caching, remote, auth).
+- **Bridge** - separate an abstraction from its implementation so both vary
+  independently. Force: a class hierarchy exploding along two dimensions.
+- **Flyweight** - share fine-grained objects to save memory. Rarely needed;
+  performance-specific.
+
+### Behavioural - how objects interact and share responsibility
+
+- **Strategy** - encapsulate interchangeable algorithms behind one interface.
+  Force: behaviour varies and you keep writing conditionals to switch it. The
+  usual cure for Switch Statements. In Ruby, often just a passed block/callable.
+- **Observer** - notify dependents when state changes. Force: many objects must
+  react to one object's changes without it knowing them (pub/sub, callbacks).
+- **Command** - wrap a request as an object. Force: you need to queue, log,
+  undo, or parameterise actions (service objects, jobs, interactors).
+- **Template Method** - fix an algorithm's skeleton, let subclasses fill steps.
+  Force: several variants share a stable overall flow.
+- **State** - let an object change behaviour when its internal state changes.
+  Force: sprawling conditionals on a status field driving behaviour.
+- **Iterator** - traverse a collection without exposing its structure. Mostly
+  built into languages (Ruby's Enumerable).
+- **Chain of Responsibility** - pass a request along handlers until one takes it
+  (middleware pipelines).
+- **Mediator** - centralise complex many-to-many communication in one object.
+- **Memento** - capture and restore an object's state without breaking
+  encapsulation (undo, snapshots).
+- **Visitor** - add operations to an object structure without changing its
+  classes. Force: stable class hierarchy, frequently added operations. Heavy;
+  use only when that trade-off is real.
+- **Interpreter** - represent and evaluate a simple grammar. Niche.
+
+## Choosing between the common ones
+
+- Varying algorithm behind one call -> **Strategy**.
+- Conditionals on a status/type that drive behaviour -> **State** or
+  **Replace Conditional with Polymorphism** (Fowler) first.
+- Optional, stackable enhancements -> **Decorator**, not subclasses.
+- Taming a messy subsystem for callers -> **Facade**.
+- Actions you must queue/undo/log -> **Command**.
+- Complex construction with many options -> **Builder**.
+- Fitting a class you cannot modify -> **Adapter**.
+
+If two patterns seem to fit, pick the one that removes the most present
+complexity with the least indirection, and name the force it addresses.
+
+## Further reading
+
+- Refactoring Guru - design patterns catalogue with diagrams and per-language
+  examples: https://refactoring.guru/design-patterns

--- a/src/claude/skills/code-craft/references/general-principles.md
+++ b/src/claude/skills/code-craft/references/general-principles.md
@@ -1,0 +1,76 @@
+# General engineering principles
+
+Distilled from *The Pragmatic Programmer* (Hunt and Thomas) and *Code Complete*
+(McConnell). Language-agnostic construction wisdom that sits underneath the more
+specific lenses. Cite the source when you apply one.
+
+## The Pragmatic Programmer
+
+- **DRY - Don't Repeat Yourself.** Every piece of knowledge has one
+  authoritative representation. DRY is about knowledge, not text: two identical
+  lines that encode different decisions are not a violation; two different lines
+  encoding the same decision are.
+- **Orthogonality.** Keep unrelated things independent so a change in one place
+  does not ripple. Decoupled components can be changed, tested, and reasoned
+  about in isolation.
+- **Reversibility.** Avoid decisions that are hard to undo; keep the design
+  flexible about databases, vendors, and frameworks where the cost is low.
+- **Tracer bullets.** Build a thin, end-to-end, working slice first, then flesh
+  it out. Distinct from a prototype, which is throwaway.
+- **Prototype to learn.** When exploring the unknown, build something disposable
+  to answer the question, then discard it.
+- **Don't live with broken windows.** Fix small problems (bad names, dead code,
+  a failing test) as you see them; neglect signals that neglect is acceptable.
+- **Design by Contract.** Be explicit about preconditions, postconditions, and
+  invariants.
+- **Crash early.** A dead program does less damage than a crippled one; fail
+  fast and loudly rather than limping on with bad state.
+- **Assertive programming.** Use assertions to state things that can never
+  happen; if they can happen, handle them as errors instead.
+- **Decoupling and the Law of Demeter.** Minimise what each module needs to know
+  about others.
+- **Configure, don't integrate.** Put changeable details in metadata/config, not
+  hard-coded in logic.
+- **"Good enough" software.** Involve users in the quality trade-off; know when
+  more polish stops paying. Ship deliberately, not perfectionistically.
+- **Estimate to avoid surprises.** Give ranges, track how estimates diverge from
+  reality, and refine.
+
+## Code Complete
+
+- **Manage complexity.** The primary technical imperative. Every technique
+  (routines, modules, abstraction, information hiding) exists to reduce the
+  amount a reader must hold in their head at once.
+- **Information hiding.** Design modules around a secret - a design decision
+  likely to change - and hide it behind a stable interface.
+- **Name well.** Names should describe the thing fully and unambiguously.
+  Variables named for their meaning, not their type; routines named for what
+  they return (functions) or what they do (procedures). Avoid abbreviations that
+  save keystrokes and cost comprehension.
+- **Strong cohesion.** A routine should do one thing completely; a class should
+  group things that genuinely belong together (functional cohesion is the goal).
+- **Loose coupling.** Minimise and simplify the connections between modules;
+  prefer passing exactly what is needed.
+- **Defensive programming.** Validate inputs at boundaries, decide barricade
+  points beyond which data is trusted, and handle the errors you can while
+  crashing early on the ones you cannot.
+- **Pseudocode Programming Process.** Write a routine's intent in precise
+  pseudocode first; refine it into comments and code. The pseudocode that
+  survives becomes the documentation.
+- **Table-driven methods.** Replace complicated conditional logic with a lookup
+  when the branches are really data.
+- **Keep routines small and single-purpose,** but let cohesion, not an arbitrary
+  line count, be the deciding measure.
+- **Refactor as construction, not repair.** Improve structure continuously as
+  understanding grows; treat code as always in draft.
+- **Programming into a language, not in it.** Let the design lead; do not let a
+  language's limits shrink your thinking.
+
+## How these interact with the specific lenses
+
+These principles agree with Metz and Fowler far more than they conflict: DRY and
+cohesion motivate Extract Function; information hiding and orthogonality
+motivate dependency injection and the Law of Demeter; managing complexity is the
+reason to keep classes and methods small. When a specific rule (e.g. Metz's
+five-line method) seems to fight readability, fall back to the general
+imperative - minimise complexity for the reader - and let that break the tie.

--- a/src/claude/skills/code-craft/references/object-oriented-design.md
+++ b/src/claude/skills/code-craft/references/object-oriented-design.md
@@ -1,0 +1,80 @@
+# Sandi Metz: object-oriented design
+
+From *Practical Object-Oriented Design in Ruby* (POODR), *99 Bottles of OOP*,
+and her "rules". Ruby-flavoured, but the intent generalises: small, focused,
+loosely-coupled objects that are cheap to change.
+
+## The four rules
+
+Heuristics, not laws. They provoke better design by making bad design
+uncomfortable. Break one only with a stated reason.
+
+1. **A class can be no longer than 100 lines of code.**
+2. **A method can be no longer than 5 lines of code.**
+3. **Pass no more than 4 parameters into a method.** Hash options count.
+4. **Controllers can instantiate only one object; views know only one instance
+   variable.** (Rails-specific. The general form: keep the boundary between HTTP
+   and the domain thin.)
+
+Some formulations add: **no more than 4 instance variables** in a class.
+
+### Counting precisely
+
+- **Class/method lines**: count lines of actual code. Exclude blank lines,
+  comments, the `def`/`class` line, and `end`.
+- **Parameters**: count all explicit params including keyword args; `&block`
+  does not count; defaults still count.
+
+### Prioritising violations
+
+- High: classes over 200 lines, methods over 10 lines, 6+ params, controllers
+  carrying business logic.
+- Medium: classes 100-200, methods 5-10, 5 params.
+- Low: borderline cases; violations in migrations, routes, DSLs, config, or
+  tests, where the rules often should be broken.
+
+## The refactorings the rules push you toward
+
+- **Long class** - extract a collaborator with its own responsibility (SRP);
+  use composition or a module. Candidate patterns: Strategy, Decorator, Command,
+  Facade.
+- **Long method** - extract well-named sub-methods at one level of abstraction
+  (Composed Method); guard clauses to flatten nesting; replace conditional with
+  polymorphism.
+- **Too many parameters** - introduce a Parameter Object for related args; move
+  the method to the class that owns the data.
+- **Fat controller** - extract a service object, use case, or interactor; move
+  domain logic out of the HTTP layer.
+
+## The design principles underneath the rules
+
+The rules are the surface; POODR's real content is managing dependencies.
+
+- **Single Responsibility** - a class should have one reason to change. Test:
+  can you describe it in one sentence without "and"?
+- **Depend on abstractions, not concretions** - inject dependencies; isolate the
+  things most likely to change. Ask "what does this message need?" not "what
+  class is this?".
+- **Law of Demeter** - talk to your immediate collaborators, not their innards.
+  `a.b.c.d` is a design smell; it couples you to a whole object graph.
+- **Tell, Don't Ask** - send an object a message describing intent; let it
+  decide how. Avoid pulling data out to make decisions the object should make.
+- **Duck typing** - depend on what an object *does*, not what it *is*. Replace
+  type-checking conditionals (`case obj.class`) with a shared message.
+- **Prefer composition over inheritance** - inheritance is for genuine is-a
+  specialisation only. Reach for composition (has-a) by default; it is easier to
+  rearrange. Use inheritance when subclasses are true refinements sharing a
+  stable interface.
+
+## When to break the rules
+
+Config, routes, migrations, generated code, DSLs, and tests are legitimate
+exceptions. The overriding test is clarity: if following a rule makes the code
+harder to understand, the rule loses. Always say *why* a violation is
+acceptable rather than silently ignoring it.
+
+## Enforcement
+
+RuboCop `Metrics/ClassLength` (100), `Metrics/MethodLength` (5),
+`Metrics/ParameterLists` (4). Reek for smells (LongMethod, LargeClass,
+LongParameterList, FeatureEnvy). flog for complexity, flay for duplication.

--- a/src/claude/skills/code-craft/references/performance.md
+++ b/src/claude/skills/code-craft/references/performance.md
@@ -1,0 +1,84 @@
+# Performance as a design concern
+
+Performance has two layers, and they call for opposite instincts. This file is
+about the first; the second is measurement-driven and mostly handled in review.
+
+- **Design-level performance** - algorithmic complexity, the data model, query
+  patterns, data-structure choice, and where the caching and sync/async
+  boundaries sit. These are *design decisions*: cheap to get right up front and
+  expensive to reverse later (Fowler's reversibility). Think about them when you
+  design.
+- **Micro-optimisation** - hand-tuning a hot loop, shaving allocations. Local,
+  low-level, and only worth doing once a profiler says so.
+
+## The order of priorities
+
+Make it **correct**, then **clear**, then **fast** - but do not read that as
+"ignore performance until the end". The design-level choices below are part of
+"clear and correct", because a design that cannot meet its performance need is
+not actually correct for its job.
+
+- **Premature optimisation is the root of all evil** (Knuth) - do not contort
+  code for speed you have not measured a need for. The flip side is also true:
+  do not choose a knowingly quadratic design when a linear one is no harder to
+  write.
+- **Measure, do not guess** (Jon Bentley, *Programming Pearls*) - before
+  optimising anything below the design level, profile to find the actual hot
+  spot. Intuition about where time goes is usually wrong.
+- Optimise only what is both hot and measured, keep the improvement (benchmark
+  before and after), and stop when it stops mattering.
+
+## Get these right at design time
+
+They are set by the shape of the design and painful to change afterwards:
+
+- **Algorithmic complexity.** Know the big-O of the operation *and* the size of
+  the data it will see in production. A linear scan is fine for 10 items and a
+  disaster for 10 million. Watch for accidental nested iteration (O(n^2)).
+- **The data model.** Schema shape, indexes, and normalisation decisions
+  dominate the performance of data-heavy systems and are among the hardest
+  things to change once there is live data.
+- **Query patterns.** How you talk to the store, not just its structure - see
+  the Rails notes below.
+- **Data-structure choice.** A hash/set for membership tests instead of an array
+  scan; the right structure removes whole classes of slow code.
+- **Boundaries: caching, sync vs async, streaming vs loading.** Decide what work
+  happens now vs in the background, what is cached and how it is invalidated,
+  and whether large results are streamed rather than loaded whole. These are
+  architectural seams, not tweaks.
+
+## Rails and ActiveRecord specifics
+
+Most Rails performance problems are design/abstraction problems in disguise:
+
+- **N+1 queries** are the classic example - an abstraction leak, not a
+  micro-issue. Use `includes`/`preload`/`eager_load`; the `bullet` gem surfaces
+  them.
+- **Do set work in the database, not in Ruby** - filter, count, and aggregate
+  with SQL rather than loading records and looping.
+- **Select only the columns you need**, and add **indexes** for the columns you
+  filter and join on; consider **counter caches** for frequent counts.
+- **Do not load huge collections into memory** - use `find_each`/`in_batches`.
+- **Move slow or external work to background jobs**, and cache expensive
+  render/compute with fragment or Russian-doll caching.
+
+## A caveat on caching
+
+Caching trades correctness risk for speed. Cache invalidation is genuinely hard,
+so add a cache to solve a *measured* problem, keep its invalidation rules
+simple, and prefer eliminating the work (a better query or index) over hiding it
+behind a cache when you can.
+
+## How this fits code-craft
+
+Clean design and performance usually pull the same way: the coupling and
+abstraction problems that `refactoring.md` and `solid.md` name are often the
+same things that make code slow (an N+1 is a leaked abstraction). Where they
+conflict, keep the code clear and isolate the optimised part behind a good
+interface, so the speed hack does not spread.
+
+## Further reading
+
+- Jon Bentley, *Programming Pearls* (design-level performance thinking).
+- Martin Kleppmann, *Designing Data-Intensive Applications* (for data systems at
+  scale).

--- a/src/claude/skills/code-craft/references/refactoring.md
+++ b/src/claude/skills/code-craft/references/refactoring.md
@@ -1,0 +1,94 @@
+# Martin Fowler: refactoring and code smells
+
+From *Refactoring: Improving the Design of Existing Code* (2nd edition).
+Language-agnostic.
+
+## The discipline
+
+Refactoring is improving the internal structure of code **without changing its
+observable behaviour**. It is not rewriting.
+
+- Work in **small, behaviour-preserving steps**.
+- **Run the tests between every step.** If there is no test coverage, add it
+  before refactoring, or refactor only under the compiler's protection using
+  the most mechanical steps.
+- Never refactor and change behaviour in the same step.
+- Refactoring is **opportunistic** - done in small doses as part of everyday
+  work, to make a needed change easier ("first make the change easy, then make
+  the easy change"), not as a separate grand-redesign phase.
+- **Economics, not aesthetics.** Favour the smallest refactoring that removes
+  the obstacle in front of you.
+
+## Code smells (Fowler's catalogue, grouped)
+
+A smell is a surface indication of a deeper problem. Naming it points to the
+cure.
+
+**Bloaters** - things that have grown too big.
+- Long Method, Large Class, Primitive Obsession (using primitives instead of
+  small objects), Long Parameter List, Data Clumps (the same group of fields
+  travelling together).
+
+**Object-orientation abusers** - OO applied incompletely.
+- Switch Statements (type-based conditionals begging for polymorphism),
+  Temporary Field, Refused Bequest (a subclass ignoring inherited behaviour),
+  Alternative Classes with Different Interfaces.
+
+**Change preventers** - one change forces many edits.
+- Divergent Change (one class changed for many different reasons), Shotgun
+  Surgery (one change scattered across many classes), Parallel Inheritance
+  Hierarchies.
+
+**Dispensables** - things adding no value.
+- Comments (often deodorant for bad code), Duplicated Code, Dead Code, Lazy
+  Class, Speculative Generality (abstraction for a future that never came),
+  Data Class.
+
+**Couplers** - excessive coupling.
+- Feature Envy (a method more interested in another class's data), Inappropriate
+  Intimacy, Message Chains (`a.b().c().d()`), Middle Man (a class that only
+  delegates), Insider Trading.
+
+## Smell to refactoring
+
+- Duplicated Code -> Extract Function/Method, Pull Up Method.
+- Long Method -> Extract Function, Replace Temp with Query, Decompose
+  Conditional, Replace Nested Conditional with Guard Clauses.
+- Long Parameter List / Data Clumps -> Introduce Parameter Object, Preserve
+  Whole Object, Replace Parameter with Query.
+- Large Class -> Extract Class, Extract Superclass, Replace Type Code with
+  Subclasses/State/Strategy.
+- Switch on type -> Replace Conditional with Polymorphism.
+- Feature Envy -> Move Function/Field.
+- Message Chains -> Hide Delegate, Extract Function.
+- Primitive Obsession -> Replace Primitive with Object, Replace Type Code with
+  Class.
+
+## Core mechanics worth knowing
+
+- **Extract Function** - name a fragment by its intent; the strongest, most-used
+  move. Prefer intent-revealing names over implementation-revealing ones.
+- **Inline Function/Variable** - when the indirection no longer earns its keep.
+- **Rename** - a rename is a real refactoring; good names are the cheapest
+  documentation.
+- **Replace Conditional with Polymorphism** - when behaviour varies by type.
+- **Introduce Parameter Object** - turn a recurring data clump into a type.
+- **Replace Temp with Query** - extract the computation behind a temp so it can
+  be reused and named.
+
+## When *not* to refactor
+
+- When you need to rewrite from scratch, or the code is about to be deleted.
+- When you are mid behaviour-change: finish that, then refactor separately.
+- When there are no tests and you cannot add them and the change is risky:
+  characterise behaviour first.
+- When "ugly but stable and untouched" code is not blocking the current change.
+  Refactor code you are about to work in, not everything you can see.
+
+## Further reading
+
+- Refactoring Guru - refactoring catalogue and smells (illustrated):
+  https://refactoring.guru/refactoring
+- thoughtbot, *Ruby Science* - Ruby/Rails-specific smells and cures (fat models,
+  callbacks, view logic, Rails anti-patterns):
+  https://thoughtbot.com/ruby-science

--- a/src/claude/skills/code-craft/references/reliability.md
+++ b/src/claude/skills/code-craft/references/reliability.md
@@ -1,0 +1,94 @@
+# Reliability: designing for failure
+
+Reliability is about behaving well when things go wrong - especially in services
+with background jobs, queues, external APIs, and networks between them. The
+techniques here are **situational design attributes**: reach for one where its
+failure mode is real, not everywhere. Adding retry or circuit-breaker machinery
+to a purely in-process, single-run operation is over-engineering.
+
+## Idempotency
+
+An operation is **idempotent** if performing it more than once has the same
+effect as performing it once. Design for it wherever an operation can run or be
+delivered more than once:
+
+- background jobs and message consumers (almost all queues are *at-least-once* -
+  a job will eventually run twice);
+- webhooks and outbound API calls that may be retried;
+- money-moving or state-changing operations where a duplicate is harmful;
+- HTTP semantics - GET, PUT, and DELETE are expected to be idempotent, POST is
+  not, so design endpoints accordingly.
+
+Ways to achieve it:
+
+- **Naturally idempotent operations** - "set status to `paid`" is safe to
+  repeat; "increment balance" is not. Prefer the former where you can.
+- **Idempotency keys** - the caller sends a unique request id; you record it and
+  ignore or return the prior result on a repeat.
+- **Upserts / find-or-create**, guarded by a **unique constraint** so a race
+  cannot create duplicates (the database is the last line of defence).
+- **Record processed message ids** and skip ones already handled.
+
+## Retries and backoff
+
+Assume transient failures (a dropped connection, a rate limit, a brief outage).
+
+- Retry with **exponential backoff plus jitter**, and a cap on attempts, so
+  retries neither hammer a struggling dependency nor synchronise into a
+  thundering herd.
+- **Only retry safe/idempotent operations** - retrying a non-idempotent write
+  can double its effect.
+- Distinguish **retryable** failures (timeouts, `5xx`, `429`) from
+  **non-retryable** ones (`4xx` validation errors); do not retry a request that
+  will always be rejected.
+
+## Timeouts
+
+- **Never make an unbounded call to anything external.** Set connect and read
+  timeouts on every HTTP client, database call, and lock acquisition.
+- A missing timeout is a latent outage: one slow dependency ties up your
+  threads or connection pool until the whole service stalls.
+
+## Delivery semantics
+
+- Most queues and job systems are **at-least-once**. True **exactly-once**
+  delivery is effectively a myth in distributed systems.
+- So aim for **effectively-once** by making consumers **idempotent** and
+  deduplicating, rather than trusting the transport to deliver exactly once.
+
+## Failure handling and graceful degradation
+
+- Decide, per dependency, what happens when it is down: fail fast, fall back to
+  a default, degrade the feature, or queue the work for later.
+- Use a **circuit breaker** for a dependency that is failing repeatedly, so you
+  stop hammering it and fail fast until it recovers.
+- Do not let a **non-critical** dependency take down the whole request (the
+  bulkhead idea - isolate failures so one leak does not sink the ship).
+- Keep failures honest: crash early on genuine programmer errors (see
+  `general-principles.md`), but handle expected external failures deliberately.
+
+## Rails and jobs specifics
+
+- Sidekiq / Active Job **retry**, so jobs **must be idempotent**. Use a unique
+  job/lock or an idempotency key; lean on a DB **unique index** as the final
+  dedup guard.
+- Wrap external calls (Faraday, `Net::HTTP`) with explicit **timeouts**.
+- Use database **transactions** for atomicity so a partial failure does not
+  leave half-applied state.
+- For webhooks you receive, store and check the provider's event id to ignore
+  redeliveries.
+
+## When not to reach for this
+
+Match the mechanism to a real failure mode. An in-process pure function does not
+need an idempotency key; a synchronous call within one request does not need a
+circuit breaker. Reliability machinery has a cost in complexity - spend it where
+the network, retries, or repeated delivery make failure genuinely likely.
+
+## Further reading
+
+- Michael Nygard, *Release It!* (timeouts, circuit breakers, bulkheads, and
+  other stability patterns).
+- Martin Kleppmann, *Designing Data-Intensive Applications* (delivery semantics,
+  consistency).
+- AWS Architecture Blog, "Exponential Backoff and Jitter".

--- a/src/claude/skills/code-craft/references/solid.md
+++ b/src/claude/skills/code-craft/references/solid.md
@@ -1,0 +1,147 @@
+# Design principles: SOLID, connascence, module depth
+
+SOLID is a widely-used acronym (coined by Michael Feathers) collecting five
+object-oriented design principles about managing dependencies so code is easier
+to change. The substance predates the acronym; each is attributed to its source
+below. Treat them as heuristics, not laws, and apply them to remove a real
+problem, not pre-emptively (YAGNI, KISS).
+
+## The five principles
+
+### S - Single Responsibility
+
+A class should have one reason to change. This is *cohesion* from structured
+design (Constantine, Yourdon, DeMarco): group what changes together, separate
+what changes for different reasons. Test: can you describe the class in one
+sentence without "and"? Metz teaches the same idea - see
+`object-oriented-design.md`. The Fowler smells it cures are Divergent Change and
+Large Class.
+
+### O - Open/Closed (Bertrand Meyer, 1988)
+
+Software entities should be open for extension but closed for modification: you
+should be able to add behaviour without editing existing, working code. Achieve
+it with polymorphism behind a stable abstraction, so a new case is a new class
+rather than another branch in a `case` statement (this is the Strategy and
+State patterns in `design-patterns.md`). Caveat: do not build the abstraction
+speculatively. Wait until a real axis of variation appears - the first time you
+would edit existing code to add a case is the signal to make it open/closed
+there.
+
+### L - Liskov Substitution (Barbara Liskov, 1987; Liskov and Wing, 1994)
+
+A subtype must be usable anywhere its supertype is expected, without surprising
+the caller. Concretely, an override must not strengthen preconditions or weaken
+postconditions, must honour the base type's invariants, and must not throw where
+the base does not. A subclass that overrides an inherited method to raise
+"not supported" violates LSP - and is Fowler's Refused Bequest smell. When a
+subtype cannot honour the contract, prefer composition over inheritance (see
+`object-oriented-design.md`).
+
+### I - Interface Segregation
+
+Clients should not be forced to depend on methods they do not use. Prefer
+several small, role-specific interfaces over one fat general-purpose one, so a
+change to one role does not ripple to unrelated clients. This is interface
+cohesion, and relates to Fowler's "role interfaces". In a duck-typed language
+like Ruby there is no `interface` keyword, so the principle becomes: keep the
+*role* an object depends on narrow - depend on the few messages you actually
+send, not on a large concrete class.
+
+### D - Dependency Inversion
+
+High-level policy should not depend on low-level detail; both should depend on
+an abstraction. In practice: depend on an interface or injected collaborator,
+not a hard-coded concrete class. This is GoF's "program to an interface, not an
+implementation" and Fowler's Inversion of Control / Dependency Injection, and it
+is the dependency-management heart of Metz's POODR
+(`object-oriented-design.md`). It is what lets you substitute a test double, or
+swap an implementation, without touching the policy.
+
+## Connascence: a finer lens on coupling
+
+Connascence (Meilir Page-Jones; popularised in the Ruby community by Jim
+Weirich) is a vocabulary for *kinds* and *strength* of coupling, more precise
+than "coupling bad" or even the Law of Demeter. Two components are connascent if
+changing one requires changing the other to keep the system correct.
+
+**Static kinds** (visible in the code), roughly weakest to strongest:
+- **Name** - agree on a name (a method name). Weakest and unavoidable.
+- **Type** - agree on a type.
+- **Meaning** - agree on the meaning of a value (e.g. `true` means admin).
+- **Position** - agree on order (positional arguments).
+- **Algorithm** - agree on an algorithm (both sides must hash the same way).
+
+**Dynamic kinds** (only at runtime), generally stronger and worse:
+- **Execution** (order of calls matters), **Timing**, **Value** (values must
+  change together), **Identity** (must reference the same instance).
+
+**Three rules of thumb:**
+1. **Minimise** overall connascence (reduce coupling).
+2. **Prefer weaker forms** - e.g. replace connascence of Position (positional
+   args) with connascence of Name (keyword arguments or a parameter object).
+3. **Keep strong connascence local** - strong coupling within one class is
+   tolerable; the same coupling across module boundaries is not.
+
+Connascence is the most actionable way to *rank* coupling problems in review.
+
+## Module depth: the counter-tension (John Ousterhout)
+
+*A Philosophy of Software Design* frames the goal as **reducing complexity**,
+and warns against over-decomposition. Its key idea, **deep modules**, is a
+useful counterweight to Metz's very small methods:
+
+- A **deep module** has a simple interface hiding a substantial implementation -
+  high value for low interface cost. A **shallow module** exposes almost as much
+  as it hides, so splitting it adds interface overhead without hiding much.
+- "Classitis" - reflexively chopping code into many tiny classes and methods -
+  can *increase* total complexity, because each boundary is another interface to
+  learn. Small is good until the cost of an extra interface exceeds the benefit
+  of the split.
+- So hold Metz's five-line rule and Ousterhout's depth together: extract to name
+  a concept and cut duplication, but not past the point where the fragments are
+  harder to follow than the whole. Judge by reader complexity, not line count.
+- Related Ousterhout ideas worth applying: **information hiding** (a module's
+  job is to hide a design decision), **define errors out of existence**
+  (design APIs so exceptional cases cannot arise), and **strategic over
+  tactical** (invest a little in design as you go rather than only ever
+  bolting on the next feature).
+
+## Model so illegal states are unrepresentable
+
+Data-structure and type choices are design decisions about *correctness and
+clarity*, not only performance. Choose the representation that makes the problem
+obvious and makes bad states hard or impossible to construct (type-driven
+design; Scott Wlaschin, *Domain Modeling Made Functional*, and Alexis King's
+"parse, don't validate"):
+
+- Replace bare primitives with **value objects** that carry their own rules (a
+  `Money`, an `EmailAddress`) - the cure for Fowler's Primitive Obsession and a
+  core Metz move (`refactoring.md`, `object-oriented-design.md`).
+- Prefer a **closed set** (an enum, or a small set of subclasses) over free-form
+  strings or boolean flags when the valid values are fixed.
+- Pick the structure that matches the access pattern **and expresses intent** -
+  a `Set` for uniqueness, a `Hash` for a mapping - so the structure itself
+  documents the constraint.
+- The aim: if a state should never occur, make the code unable to represent it,
+  rather than guarding against it at every call site. This removes whole classes
+  of bug and defensive checks (validate once at the boundary, then trust the
+  type).
+
+## How this fits the rest of code-craft
+
+- SRP and DIP are the principled statement of what `object-oriented-design.md`
+  teaches.
+- OCP, ISP, and DIP are why the `design-patterns.md` patterns exist (Strategy,
+  Decorator, and the rest are ways to be open/closed and depend on
+  abstractions).
+- Connascence refines the coupling smells in `refactoring.md` into a ranking.
+- Ousterhout's depth keeps the "make everything tiny" instinct honest.
+
+## Further reading
+
+- Bertrand Meyer, *Object-Oriented Software Construction* (Open/Closed).
+- Barbara Liskov and Jeannette Wing, "A Behavioral Notion of Subtyping" (1994).
+- Meilir Page-Jones, *What Every Programmer Should Know About Object-Oriented
+  Design*; https://connascence.io for a concise catalogue.
+- John Ousterhout, *A Philosophy of Software Design*.

--- a/src/claude/skills/code-craft/references/testing.md
+++ b/src/claude/skills/code-craft/references/testing.md
@@ -1,0 +1,205 @@
+# Testing as design
+
+Good tests are a design tool, not a box to tick. This file gathers the lenses
+worth applying when writing or reviewing tests. Cite the source when you apply
+one. None of these are compulsory: they are frames for deciding, not rules to
+obey.
+
+## Five-factor testing (Sarah Mei)
+
+A test has no inherent value. It is worth having only insofar as it supports one
+or more of these five factors:
+
+1. **Verify the code is working correctly** - immediate confidence that what you
+   wrote does what you think.
+2. **Prevent future regressions** - part of the suite that tells the next person
+   they did not break your work.
+3. **Document the code's behaviour** - executable documentation that cannot go
+   stale; the easiest way to show intended use and edge cases.
+4. **Provide design guidance** - writing a test gives the code a *secondary
+   client*, forcing a small, non-speculative amount of generality and surfacing
+   awkward design before it sets. Hard-to-test code is a design signal, not a
+   testing problem.
+5. **Support refactoring** - tests at the right level let you rearrange code
+   underneath a stable interface without fear.
+
+### How to use the factors
+
+- This is a **framework for discussing test strategy, not a checklist**. You
+  cannot maximise all five at once; they are in tension. Comprehensive unit
+  tests document well (3) but ossify an interface, hurting refactoring (5).
+  Slow top-level integration tests prove behaviour (1) and document (3) but, as
+  they slow the suite, weaken regression value (2) because people stop running
+  them.
+- In review, ask of each test: **which factors does it serve, and are they the
+  right ones here?** A test optimising for a factor that does not matter at this
+  spot can often be simplified or deleted.
+- Match strategy to the code's role: a rarely-changing public API leans toward
+  documentation (3); a churny internal class leans toward light regression tests
+  (2) that leave it free to refactor (5).
+- Treat tests as living documents. As the team's needs change, the tests that
+  earn their keep change too.
+
+Vladimir Khorikov's "four pillars of a good test" (protection against
+regressions, resistance to refactoring, fast feedback, maintainability) is a
+more formal restatement of the same idea; reach for it when you want a rigorous
+frame.
+
+## What to test: the Magic Tricks (Sandi Metz)
+
+The most actionable rules for deciding *what* a unit test should assert. Test an
+object's interface, not its internals, by classifying each message:
+
+| Message type | Definition | Test by |
+|---|---|---|
+| Incoming query | Returns a value, no side effect | Asserting the returned value |
+| Incoming command | Causes a side effect | Asserting the direct public side effect |
+| Sent to self (private) | Internal | Do not test at all |
+| Outgoing query | You send it, no side effect on others | Ignore (it is the receiver's incoming query) |
+| Outgoing command | You send it, causes a side effect elsewhere | Expecting it was sent (a mock) |
+
+Rules of thumb: **test the incoming and the outgoing commands; ignore the
+rest.** Never test private methods directly - if you feel you must, it is a sign
+the object wants splitting. Assert on messages at the object's boundary, so
+tests survive refactoring of the guts.
+
+## Listen to the tests (GOOS, Freeman and Pryce)
+
+*Growing Object-Oriented Software, Guided by Tests* turns factor 4 into a
+practice: **test pain is design feedback.** If a test needs a huge fixture, deep
+mock chains, or many collaborators just to run, the object under test is telling
+you it has too many dependencies, is doing too much, or is missing a
+collaborator to talk to. Fix the design, not the test.
+
+- **Outside-in TDD** - start from the outermost behaviour you want (an
+  acceptance test), and let the objects and their roles emerge as you drive
+  inward. Discover interfaces by using them from the test first.
+- **Mock roles, not objects** - mock the interface a collaborator plays, not a
+  concrete class, so the test documents a genuine seam in the design.
+- Only mock types you own; wrap third-party APIs behind your own interface
+  (ports and adapters) and mock that.
+
+## Test doubles and the mockist / classicist choice
+
+Fowler's "Mocks Aren't Stubs" gives the vocabulary and the debate.
+
+**The five doubles (Meszaros):**
+- **Dummy** - passed but never used, just to fill a signature.
+- **Stub** - returns canned answers to calls made during the test.
+- **Spy** - a stub that also records how it was called.
+- **Mock** - pre-programmed with expectations; verification is the assertion.
+- **Fake** - a working but simplified implementation (e.g. an in-memory repo).
+
+**Two schools:**
+- **Classicist / Detroit / sociable** - use real collaborators where cheap; test
+  a cluster through its outermost object; double only awkward dependencies
+  (network, time, randomness). Fewer doubles, tests survive internal
+  refactoring, but failures localise less precisely.
+- **Mockist / London / solitary** - isolate the unit and double every
+  collaborator. Failures pinpoint the class, and it drives interface discovery
+  (GOOS), but tests couple tightly to the interaction and can ossify.
+
+Default to the classicist style for internal logic (it protects refactoring),
+and reach for mockist isolation at genuine seams and outgoing commands. Double
+what is slow, non-deterministic, or has real side effects; use the real thing
+otherwise.
+
+## Test smells (Meszaros)
+
+Tests rot in recognisable ways; naming the smell points to the cure.
+
+- **Fragile Test** - breaks on unrelated changes. Usually over-mocking or
+  asserting on internals; assert on behaviour at the boundary instead.
+- **Obscure Test** - the reader cannot tell what is being verified. Extract
+  setup, name things, use the four-phase shape (arrange, act, assert, teardown).
+- **Mystery Guest** - the test depends on external data not visible in the test.
+  Make the relevant fixture explicit and local.
+- **Test Code Duplication** - the same setup copy-pasted. Extract helpers or
+  factories, but keep each test's intent readable.
+- **Erratic / Flaky Test** - passes and fails non-deterministically. Remove
+  shared state, time, ordering, and network dependence.
+- **Slow Test** - see the pyramid; push it down a level.
+
+## The practical test pyramid (Fowler)
+
+Write tests at different granularities, and **the higher the level, the fewer
+you should have**.
+
+- **Unit (broad base)** - a unit from a single method to a class, in isolation,
+  fast. Test observable behaviour, not implementation detail. The bulk of the
+  suite.
+- **Integration (middle)** - the code working with a real external part
+  (database, filesystem, another service), one integration point at a time. Use
+  test doubles for third parties where sensible.
+- **End-to-end / UI (narrow top)** - the whole system through its UI or API.
+  Notoriously slow and flaky; reserve for a few critical user journeys.
+
+### Principles
+
+- **Push tests as far down the pyramid as you can.** If a lower, faster test can
+  give the same confidence, prefer it.
+- **Avoid the ice-cream cone** - the inverted shape (many slow e2e tests, few
+  unit tests) that is slow, flaky, and hard to diagnose.
+- **Do not duplicate coverage across layers.** Once a lower level proves a
+  detail, do not re-assert it higher up; higher tests should cover integration
+  and journeys, not logic already pinned below.
+- Keep the suite fast enough that people actually run it (Mei's rough threshold:
+  once it passes ~ten minutes, start speeding it up), because a suite people
+  skip stops preventing regressions.
+
+Kent C. Dodds' **Testing Trophy** is the modern counterpoint, especially in
+frontend/JS: bias toward integration tests as the best confidence-per-cost, with
+static analysis and types forming the base. Use it when end-to-end behaviour and
+component integration matter more than isolated units.
+
+## BDD and Given-When-Then (Cucumber and friends)
+
+Behaviour-Driven Development (Dan North) reframes TDD around behaviour described
+in domain language rather than "tests." Its scenario shape is **Given** a
+context, **When** an event, **Then** an outcome. **Cucumber** makes this literal
+and executable: plain-language Gherkin feature files wired to step definitions,
+readable by non-developers.
+
+This is **one option, not a default.** Given-When-Then is a convention you can
+apply anywhere - it is the same shape as Arrange-Act-Assert, and RSpec's
+`describe`/`context`/`it` is already BDD-flavoured - so you do not need Cucumber
+or Gherkin to get its benefit. Reach for full Gherkin/Cucumber when the
+readable, stakeholder-facing spec is itself valuable (shared acceptance criteria
+with product or users); skip it when the step-definition layer would be pure
+overhead and a plain feature spec or request spec would document the journey
+just as well.
+
+Where it fits: acceptance scenarios sit at the **top of the pyramid**, strong on
+factor 1 (verify) and especially factor 3 (document), and slow. So express a few
+**critical user journeys in domain language**, and push exhaustive edge cases
+and logic down to faster unit and integration tests rather than enumerating them
+in Gherkin.
+
+## The design-guidance connection
+
+Everything above points one way: if code is hard to test, the fix is usually a
+design change, not a cleverer test. A fat constructor, Feature Envy, or a
+missing collaborator shows up first as test pain. That is Metz's and Fowler's
+advice arriving through the test suite - which is why testing lives inside
+code-craft rather than beside it.
+
+## Relation to your workflow
+
+Your always-on TDD habit (write the failing test first, confirm it fails for the
+right reason) lives in CLAUDE.md and is not repeated here. This file is the
+*why* and *what-level* behind that habit.
+
+## Further reading and other frameworks
+
+- Sarah Mei, "Five Factor Testing" (Made in Tandem).
+- Sandi Metz, "The Magic Tricks of Testing" (RailsConf talk).
+- Freeman and Pryce, *Growing Object-Oriented Software, Guided by Tests*.
+- Martin Fowler, "The Practical Test Pyramid" and "Mocks Aren't Stubs" -
+  https://martinfowler.com/articles/practical-test-pyramid.html
+- Dan North, "Introducing BDD".
+- Gerard Meszaros, *xUnit Test Patterns* (test doubles and test smells).
+- Vladimir Khorikov, *Unit Testing: Principles, Practices, and Patterns*.
+- **F.I.R.S.T.** - Fast, Independent, Repeatable, Self-validating, Timely.
+- Kent Beck, "Test Desiderata" (12 properties of a good test).
+- Michael Feathers, *Working Effectively with Legacy Code* (characterization
+  tests, seams).

--- a/src/claude/skills/ui-craft/SKILL.md
+++ b/src/claude/skills/ui-craft/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: ui-craft
+description: >-
+  Apply the combined lens of usability (Steve Krug's "Don't Make Me Think",
+  Jakob Nielsen's heuristics, Don Norman) and accessibility (WCAG 2.2, the
+  GOV.UK Design System and Design Principles, the dxw accessibility manual) when
+  designing, building, or reviewing user interfaces - web pages, Rails views,
+  forms, navigation, content, and visual design. Use when creating or changing
+  UI markup, templates, or flows, reviewing a screen or form, writing
+  user-facing content or alt text, choosing colours or typography, or when the
+  user mentions usability, UX, accessibility, a11y, WCAG, screen readers, alt
+  text, colour contrast, semantic HTML, heuristics, or Steve Krug. For code
+  quality, refactoring, patterns, and test design in non-UI code, use the
+  code-craft skill instead.
+---
+
+# ui-craft
+
+A single lens for building interfaces people can actually use, combining two
+complementary concerns that a good reviewer applies together:
+
+- **Usability** (Krug, Nielsen, Norman) - can a user understand and act without
+  effort?
+- **Accessibility** (WCAG / GOV.UK / dxw) - can everyone, including disabled
+  users and assistive-technology users, do so?
+
+These reinforce each other far more than they conflict: an accessible interface
+is almost always more usable, and Krug's "don't make me think" is the usability
+statement of what accessibility enforces structurally.
+
+## The guiding principle
+
+Reduce the effort a user must spend to understand and act. Every question a page
+forces ("Where am I? Is this clickable? What went wrong? What is this image?")
+is friction, and for an assistive-technology user that friction is often a hard
+barrier rather than a mild annoyance. Prefer semantic, conventional, plainly
+labelled interfaces over clever ones.
+
+## Cite your sources
+
+When you apply a principle, name where it comes from so the reasoning is
+traceable - "Krug: make the clickable things obviously clickable", "Nielsen:
+visibility of system status", "WCAG 2.2 AA: body text needs 4.5:1 contrast",
+"GOV.UK error message component". In commit messages, cite in the body where it
+adds useful context, not as decoration.
+
+## Learning mode
+
+The user treats design choices as learning opportunities, not just output. When
+you apply a named idea from the references (a usability heuristic, an
+accessibility/WCAG criterion, a Norman or Krug principle), name it and say
+briefly why it applies here. On a good teaching moment - a non-trivial layout,
+component, form, or interaction decision - offer (do not force) a short
+exercise, and engage the `learning-opportunities` skill on that specific
+principle rather than a generic prompt. Skip this for trivial or mechanical
+changes.
+
+## Two modes
+
+**Build** - reach for the right semantic element first, label everything, follow
+conventions, and meet the accessibility baseline as you write markup, not as a
+later pass. In a Service Standard context, prefer GOV.UK Design System
+components, but test the assembled result regardless.
+
+**Review** - walk the interface as a first-time user and as an assistive-tech
+user. Nielsen's ten heuristics are a good systematic checklist. Flag each spot
+where either user would have to stop and ask a question, cite the principle and
+(for accessibility) the WCAG criterion or GOV.UK guidance, and rank by impact.
+Accessibility failures that block a task outrank cosmetic usability nits.
+
+## Which reference to read when
+
+Read only what the task needs; each file is self-contained.
+
+| Situation | Read |
+|---|---|
+| Overall usability, heuristics, navigation, clarity, "does this make me think?" | `references/usability.md` |
+| Markup, semantics, ARIA, landmarks, headings, accessible names, focus | `references/accessible-code.md` |
+| Alt text, link text, headings, plain language, media, data/tables | `references/content.md` |
+| Anything to do with forms - flow, labels, fields, errors, confirmation | `references/forms.md` |
+| Colour contrast, using colour, typography, visual design | `references/visual-design.md` |
+
+Most real UI work touches more than one. A typical flow: get the structure and
+semantics right (`accessible-code`), make it usable and conventional
+(`usability`), write clear content and labels (`content`), handle any forms
+(`forms`), and check the visual layer (`visual-design`). The three accessibility
+files share one frame - WCAG's POUR principles (Perceivable, Operable,
+Understandable, Robust), set out at the top of `accessible-code.md`.
+
+## Context note
+
+The accessibility references lean on the GOV.UK Design System and dxw's
+accessibility manual, which is the right default for GOV.UK and public-sector
+service work. The underlying standards (WCAG 2.2 AA, semantic HTML) apply to any
+web interface; adapt the GOV.UK-specific component advice to the design system
+in front of you.

--- a/src/claude/skills/ui-craft/references/accessible-code.md
+++ b/src/claude/skills/ui-craft/references/accessible-code.md
@@ -1,0 +1,163 @@
+# Writing accessible code
+
+How code is written directly determines how assistive technologies interpret a
+page. Grounded in WCAG 2.2 AA, with practical conventions from the GOV.UK Design
+System and the dxw accessibility manual. Where a point is a house convention
+rather than a hard requirement, it is flagged as such.
+
+## The POUR frame (shared by all accessibility references)
+
+WCAG organises accessibility under four principles. Use them as the checklist
+spine across `accessible-code.md`, `content.md`, `forms.md`, and
+`visual-design.md`:
+
+- **Perceivable** - users can perceive the information (text alternatives,
+  captions, sufficient contrast, content not conveyed by colour alone).
+- **Operable** - users can operate the interface (keyboard operable, visible
+  focus, enough time, no seizure triggers, clear navigation).
+- **Understandable** - information and operation are understandable (readable
+  language, predictable behaviour, input help and error handling).
+- **Robust** - content works across user agents and assistive technologies
+  (valid, semantic markup; correct name, role, value).
+
+This file covers the developer's share: mostly Robust (semantics) and Operable
+(keyboard and focus).
+
+## Semantic structure (Robust)
+
+### Language
+
+- Set `lang` on `<html>` (e.g. `<html lang="en">`) so screen readers use the
+  right pronunciation. Mark inline foreign-language fragments with their own
+  `lang`.
+
+### Titles and headings
+
+- Every page needs unique `<title>` and `<h1>` content (they may match each
+  other, but should differ from other pages).
+- Headings follow a logical order and never skip levels; one `<h1>` per page.
+- (Heading *wording* is covered in `content.md`.)
+
+### Landmark elements
+
+Landmarks (`<header>`, `<nav>`, `<main>`, `<footer>`) give screen readers a
+broad outline to navigate by:
+
+- Exactly one `<main>` per page, containing the primary content.
+- Add a skip-to-main-content link at the top when the header repeats navigation.
+- If a landmark appears more than once (e.g. two `<nav>` blocks), give each a
+  unique label via `aria-labelledby` or `aria-label`.
+- A top-level native `<header>`/`<footer>` already maps to the `banner` /
+  `contentinfo` landmarks, so you do not need to add those roles. Only reach for
+  explicit roles to disambiguate, or when the element is nested inside another
+  landmark (where it loses the implicit mapping).
+
+## Use the right HTML element (Robust)
+
+The right native element gives you role, focusability, keyboard behaviour, and
+semantics for free. Compare a link built from a `<div>`:
+
+```html
+<div role="link" tabindex="0" onclick="doSomething()" onkeydown="doSomethingIfEnterKey()" class="app-link">
+  Link text
+</div>
+```
+
+against the native element:
+
+```html
+<a href="/page-link">Link text</a>
+```
+
+The first rule of ARIA is: do not use ARIA if a native element will do.
+
+- Check for a native element with the right default role before reaching for
+  ARIA.
+- If you assign a role manually, you own all the expected behaviour (e.g.
+  `role="button"` needs a click handler, `tabindex="0"`, and Enter/Space key
+  handling).
+- Never give an element a role that conflicts with its semantics, and do not
+  override elements that already carry the right ones.
+- For genuinely custom widgets (menus, comboboxes, tabs), follow the
+  [WAI-ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/) rather
+  than inventing interaction patterns.
+
+## Naming interactive elements (Robust)
+
+Buttons, links, and inputs must have unique, meaningful accessible names; the
+visible text is the default name.
+
+- If visible text is not unique (e.g. several "Edit" buttons in a table), add
+  visually hidden context saying which record each relates to.
+- For icon-only controls with no visible text, you need a name from somewhere.
+  dxw's convention is to prefer visually hidden text (a CSS class) over
+  `aria-label`, because some screen readers skip `aria-label` when translating a
+  page and it can override an existing name. `aria-label` is still valid and
+  common; treat visually-hidden-text as the safer default, not a prohibition.
+- All `<input>` elements need an associated `<label>`. (Form specifics live in
+  `forms.md`.)
+
+### Checking accessible names
+
+- Hover an element with the browser's element selector tool to see its computed
+  name.
+- Open your browser's accessibility inspector (the accessibility tree/pane in
+  its developer tools; most major browsers have one) to see how the name was
+  derived.
+
+## Keyboard and focus (Operable)
+
+Everything must work without a mouse, and the user must always be able to see
+where they are.
+
+- **Focus order** follows the visual/reading order; do not use positive
+  `tabindex` values to reorder. Only make natively-focusable elements focusable
+  (or add `tabindex="0"` to custom controls); use `tabindex="-1"` for
+  programmatic-only focus.
+- **No keyboard traps** - focus can always move on; the one deliberate exception
+  is a modal, which should trap focus while open and restore it on close.
+- **Visible focus** - include `:focus` (prefer `:focus-visible`), `:active`, and
+  `:hover` states. If the design system has no focus style, keep the browser
+  default; never remove an outline without replacing it. WCAG 2.2 also requires
+  the focused element not be fully hidden behind sticky headers/footers
+  (Focus Not Obscured, 2.4.11).
+- **Focus management for dynamic content** - when content appears or the view
+  changes without a full page load (modals, Turbo/SPA navigation, async
+  results), move focus deliberately (into the dialog, to the new `<h1>`, or to
+  an error summary) so keyboard and screen-reader users are not stranded.
+- **Target size** - WCAG 2.2 AA (2.5.8) wants interactive targets at least
+  24×24 CSS px, or with equivalent spacing. (Layout-side guidance in
+  `visual-design.md`.)
+
+## Announcing change (Operable / Robust)
+
+- Use a **live region** (`aria-live="polite"`, or `role="status"` /
+  `role="alert"`) to announce async updates (results loaded, item saved, an
+  error) that happen without a page load, so screen-reader users hear them.
+- Respect **`prefers-reduced-motion`**: gate non-essential animation and
+  transitions behind the media query, and avoid anything that flashes more than
+  three times a second (seizure risk).
+
+## Testing (do not ship on inspection alone)
+
+- **Automated**: run axe (axe DevTools / `axe-core`), Lighthouse, or WAVE. These
+  catch perhaps a third of issues - necessary, not sufficient.
+- **Manual keyboard**: tab through the whole page; can you reach and operate
+  everything, in a sensible order, with focus always visible?
+- **Screen reader**: test with at least one real screen-reader-and-browser
+  combination (for example VoiceOver with Safari, or NVDA with Firefox); the
+  accessibility tree tells you the computed semantics but not the lived
+  experience.
+
+## See also
+
+- Forms (labels, fieldsets, error association and summaries) - `forms.md`.
+- Wording of names, headings, and alt text - `content.md`.
+- Contrast, non-colour state cues, zoom/reflow - `visual-design.md`.
+
+## Further reading
+
+- WCAG 2.2 quick reference - https://www.w3.org/WAI/WCAG22/quickref/
+- WAI-ARIA Authoring Practices Guide - https://www.w3.org/WAI/ARIA/apg/
+- dxw accessibility manual - https://accessibility.dxw.com/development/writing-acessible-code/
+- MDN accessibility - https://developer.mozilla.org/en-US/docs/Web/Accessibility

--- a/src/claude/skills/ui-craft/references/content.md
+++ b/src/claude/skills/ui-craft/references/content.md
@@ -1,0 +1,105 @@
+# Accessible content
+
+Content is where Perceivable and Understandable (the middle two POUR principles)
+are mostly won or lost. Grounded in WCAG 2.2 AA, the dxw accessibility manual,
+and GDS Content Design. Forms are covered separately in `forms.md`.
+
+## Plain, readable language (Understandable)
+
+- Use plain language; avoid jargon and complex sentence structures. GOV.UK aims
+  for a reading age of around 9 - not because users cannot read, but because
+  everyone, including experts and stressed or distracted users, reads simple
+  text faster.
+- Short sentences, short paragraphs, one idea at a time.
+- Prefer the active voice ("we will email you", not "you will be emailed").
+- Explain technical or legal terms the first time they must appear; better, find
+  a common-language alternative.
+- Structure content with headings, short paragraphs, and lists so it can be
+  scanned (see `usability.md` - people scan, they do not read).
+
+## Headings as a navigation aid (Perceivable / Operable)
+
+Screen-reader users jump between headings to scan a page, so headings are
+structure, not decoration. (The markup rules - one `<h1>`, no skipped levels -
+are in `accessible-code.md`; this is about *wording*.)
+
+- Make each heading descriptive and frontloaded, with the most important word
+  first ("Report a change", not "How to report a change to us").
+- Use headings to break content into logical sections a user can navigate by.
+- Never style body text as a heading (or vice versa) just for visual effect.
+
+## Link text (Perceivable / Understandable)
+
+Screen readers can list all links out of context, so link text must make sense
+on its own.
+
+- Never use generic text like "click here", "read more", or "find out more".
+- Start with a verb when you want the user to act ("check your application
+  status").
+- Match the link text to the destination page's title where you can.
+- Use the same text for links going to the same place, and different text for
+  links going to different places.
+
+### Links, dexterity, and density (Operable)
+
+- Avoid single-word links; they are small targets for people with motor
+  difficulties (see also target size in `accessible-code.md`).
+- Do not crowd links together; give them adequate spacing.
+- Do not overload a page with links - it overwhelms everyone.
+- Link to the page that hosts a document rather than directly to the file, so
+  users get context (and format/size) before downloading.
+
+## Alt text for images (Perceivable)
+
+All non-text content needs a text alternative. Good alt text:
+
+- Conveys the same information or function the image does, in context.
+- Is concise - a short phrase, not a paragraph.
+- Does not start with "image of" or "photo of"; assistive tech already announces
+  it as an image.
+- Is empty (`alt=""`) for purely decorative images, so screen readers skip them.
+
+Use the [W3C alt-decision tree](https://www.w3.org/WAI/tutorials/images/decision-tree/)
+to decide what (if anything) an image needs. Note: the dxw convention of ending
+alt text with a full stop (to encourage a pause) is a house style, not a WCAG
+requirement - harmless, but do not rely on it for meaning.
+
+### Alt text for charts and data visualisations
+
+Short alt rarely describes a chart adequately. Amy Cesal's pattern works well:
+
+```
+alt="[chart type] of [type of data] where [key finding or reason for including it]"
+```
+
+```html
+<img src="admissions-chart.png"
+     alt="Pie chart of 2022 school admissions where 43% of children did not get their preferred choice.">
+```
+
+Also link to the underlying data, and give complex visualisations a short
+text explanation visible to everyone, not hidden in alt.
+
+## Video and audio (Perceivable)
+
+- **Video**: captions/subtitles, a transcript (including non-speech audio), and
+  audio description (or an alternative version with it).
+- **Audio-only** (e.g. a podcast): a descriptive transcript.
+- You do not need these when the media is itself the text alternative for
+  something else.
+
+## Presenting data and tables (Perceivable / Robust)
+
+- Use tables only for genuinely tabular data, never for layout.
+- Give tables proper headers (`<th>`) with correct `scope`, and a `<caption>`
+  describing the table.
+- For a complex table, first ask whether the data can be split or presented more
+  simply; consider offering it in more than one format (a table plus a summary
+  sentence).
+
+## Further reading
+
+- dxw accessibility manual - https://accessibility.dxw.com/content/
+- GDS Content Design guidance - https://www.gov.uk/guidance/content-design
+- GOV.UK style guide - https://www.gov.uk/guidance/style-guide
+- W3C images tutorial - https://www.w3.org/WAI/tutorials/images/

--- a/src/claude/skills/ui-craft/references/forms.md
+++ b/src/claude/skills/ui-craft/references/forms.md
@@ -1,0 +1,102 @@
+# Forms
+
+Forms are where a lot of real interaction happens, and where usability and
+accessibility problems hurt users most. This is the single home for form
+guidance; `accessible-code.md`, `content.md`, and `usability.md` defer here. The
+guidance below is general; points that are a GOV.UK convention rather than a
+universal rule are flagged, and GOV.UK-specific components are gathered at the
+end. Grounded in WCAG 2.2 AA, Luke Wroblewski's *Web Form Design*, the dxw
+accessibility manual, and the GOV.UK Design System.
+
+## Flow and structure
+
+- **Keep each screen focused.** Asking a single question (or one tightly related
+  group) per screen lowers cognitive load, makes error recovery easier, and
+  works better on small screens and for screen readers. This is GOV.UK's "one
+  thing per page" default, and a good default generally; a well-grouped single
+  page can be fine for short forms.
+- **Order deliberately.** Put eligibility and filtering questions first so
+  people who need not continue find out early.
+- **Use conditional logic** so users only see questions relevant to them,
+  instead of "if this applies to you" branches within a page.
+- **Ask for the minimum.** Every field is a cost and a reason to abandon. For
+  each one, ask who uses the answer and what breaks if you drop it. Do not
+  collect data you do not need.
+- **Group related fields** in a `<fieldset>` with a `<legend>` (e.g. the parts
+  of an address, or a single question with radio options).
+
+## Labels and field markup (Robust)
+
+- Every input has an associated, ideally visible, `<label>` (`for`/`id`, or
+  wrapping). A visible label beats a placeholder - placeholders vanish on input,
+  are low-contrast, and are not a reliable accessible name.
+- Do not use a placeholder as the only label. If you use placeholders, use them
+  for genuine examples, and still provide a real label.
+- For a group of controls answering one question (radios, checkboxes), the
+  `<legend>` is the question and each `<label>` is an option.
+- Mark required vs optional unambiguously. One low-noise convention (GOV.UK's)
+  is to mark the few optional fields "(optional)" rather than starring the many
+  required ones.
+- Attach help text (hints, examples, where to find information) to the field via
+  `aria-describedby`, not as ambiguous nearby prose.
+
+## Inclusive field design
+
+Do not encode narrow assumptions about people into fields:
+
+- Do not restrict text to Latin characters - names include accents and
+  non-Latin scripts.
+- Do not set minimum lengths on names - some are very short.
+- Do not offer only "female/male" for gender (listed alphabetically to avoid
+  implying a default), and only ask when you genuinely need it.
+- Do not impose time limits on completion; if a technical timeout is
+  unavoidable, warn the user and let them extend it (WCAG 2.2.1).
+- Do not use CAPTCHAs that depend on interpreting images, maths, or puzzles;
+  prefer accessible anti-spam approaches.
+- **Accept input in whatever format users have it**, then normalise in code
+  (e.g. a card number or phone number with or without spaces and punctuation).
+  Do not reject formatting differences.
+- Set `autocomplete` attributes and an appropriate `inputmode`/`type` so
+  browsers can autofill and mobile keyboards suit the field.
+
+## Errors (Understandable)
+
+- **Prevent first** (WCAG best practice, and Nielsen): good defaults, clear
+  formats, and confirmation for consequential or destructive actions beat any
+  message.
+- **Validate helpfully.** Say what is wrong and how to fix it, in plain
+  language, next to the field - not a generic banner and not jargon.
+- **Show an error summary.** On a failed submit, list each error at the top of
+  the page as a link to its field, and move focus to the summary. This is what
+  screen-reader and keyboard users rely on to find the errors at all. (The
+  GOV.UK error-summary component implements exactly this pattern.)
+- **Do not rely on colour alone** to mark errors - pair it with text and a clear
+  position or icon.
+- **Preserve the user's input** on failure; never make them re-type.
+- Associate each message with its field programmatically (`aria-describedby`,
+  plus `aria-invalid` on the input).
+
+## Confirmation and next steps
+
+After submission, tell the user:
+
+- what they submitted (or that a copy has been sent to them);
+- what happens next, and any deadline, if there is one;
+- whether they need to do anything else, and how.
+
+## GOV.UK components (when in that context)
+
+For Service Standard work, prefer the tested building blocks over rolling your
+own: the
+[error message](https://design-system.service.gov.uk/components/error-message/),
+[error summary](https://design-system.service.gov.uk/components/error-summary/),
+[text input](https://design-system.service.gov.uk/components/text-input/),
+[radios](https://design-system.service.gov.uk/components/radios/), and the
+[question pages pattern](https://design-system.service.gov.uk/patterns/question-pages/).
+Still test the assembled form as you would hand-written markup.
+
+## Further reading
+
+- Luke Wroblewski, *Web Form Design: Filling in the Blanks*.
+- GOV.UK Design System - form components and patterns - https://design-system.service.gov.uk/
+- dxw accessibility manual - accessible forms - https://accessibility.dxw.com/content/

--- a/src/claude/skills/ui-craft/references/usability.md
+++ b/src/claude/skills/ui-craft/references/usability.md
@@ -1,0 +1,135 @@
+# Usability
+
+From Steve Krug's *Don't Make Me Think*, Jakob Nielsen's usability heuristics,
+Don Norman's *The Design of Everyday Things*, and the GOV.UK Design Principles.
+The goal: interfaces a user understands and can act on without conscious effort.
+
+## Krug's first law: don't make me think
+
+Every question a page forces the user to ask ("Where am I? Where do I start? Is
+this clickable? Is this the same as that?") is friction. A page should be
+**self-evident** - obvious at a glance. Where that is impossible (complex flows,
+novel interactions), aim for **self-explanatory**: no instructions needed to
+work out what to do next.
+
+### How people really use interfaces
+
+Design for these facts, not for an idealised attentive reader.
+
+- **We scan, we don't read.** Users glance for something matching their goal.
+  Support scanning with clear headings, short paragraphs, lists, and highlighted
+  keywords.
+- **We satisfice, we don't optimise.** Users pick the first reasonable option,
+  not the best one. Make good options obvious and hard to miss.
+- **We muddle through.** Users rarely read instructions; they form a rough
+  mental model and press on, keeping it even when wrong. Make the right path the
+  path of least resistance.
+
+### Krug's practical rules
+
+- **Clear visual hierarchy** - more important means more prominent; related
+  things grouped; the appearance mirrors the structure of the content.
+- **Follow conventions** - established patterns (nav placement, link styling, a
+  clickable logo home) spend none of the user's thinking budget. Innovate only
+  where it clearly pays.
+- **Make clickable things obviously clickable** and non-clickable things
+  obviously not.
+- **Omit needless words. Then omit half of what's left.** Cut instructions,
+  welcome text, and happy talk so the meaningful content stands out.
+- **Break the page into clearly defined areas** so users can decide fast what to
+  focus on and what to ignore. Minimise noise.
+
+## Nielsen's 10 usability heuristics
+
+The standard checklist for a systematic review (heuristic evaluation). Walk the
+interface against each:
+
+1. **Visibility of system status** - the system keeps users informed through
+   timely feedback (loading, saved, progress).
+2. **Match between system and the real world** - speak the user's language and
+   follow real-world conventions, not internal jargon.
+3. **User control and freedom** - clear exits, undo and redo; do not trap users
+   in a flow.
+4. **Consistency and standards** - same words and actions mean the same thing;
+   follow platform conventions.
+5. **Error prevention** - design so mistakes cannot happen (constraints,
+   confirmations, good defaults), better than good error messages.
+6. **Recognition rather than recall** - make options and information visible;
+   do not force users to remember things across screens.
+7. **Flexibility and efficiency of use** - accelerators for experts that do not
+   get in beginners' way.
+8. **Aesthetic and minimalist design** - no irrelevant or rarely-needed
+   content; every extra unit competes with the relevant ones.
+9. **Help users recognise, diagnose, and recover from errors** - plain-language
+   messages that state the problem and suggest a fix.
+10. **Help and documentation** - ideally unnecessary, but when needed, easy to
+    search, task-focused, and concrete.
+
+## Norman: the theory underneath
+
+*The Design of Everyday Things* explains *why* the above works.
+
+- **Affordances and signifiers** - an affordance is a possible action; a
+  signifier is the perceivable cue that advertises it. "Make clickable things
+  look clickable" is a plea for good signifiers. A button that does not look
+  pressable has the affordance but lacks the signifier.
+- **Mapping** - controls should map naturally to their effects (spatial layout
+  matching real arrangement, order matching sequence).
+- **Feedback** - every action needs a prompt, visible response; silence makes
+  users repeat or abandon actions (ties to Nielsen 1).
+- **Conceptual model** - the interface should project a model that matches how
+  users think about the task, so their guesses are right.
+- **Constraints** - limit possible actions to prevent error (ties to Nielsen 5).
+- **Slips vs mistakes** - slips are right-intention wrong-action (fix with
+  better signifiers and constraints); mistakes are wrong-intention (fix with a
+  clearer conceptual model). Design for both; assume human error is normal.
+
+## Interaction laws worth knowing
+
+- **Fitts's Law** - time to hit a target grows with distance and shrinks with
+  size. Make important and frequent targets large and close; do not place tiny
+  controls far from where the user is looking. (See also dexterity and
+  link-spacing guidance in `content.md`.)
+- **Hick's Law** - decision time grows with the number and complexity of
+  choices. Reduce and group options; reveal advanced choices progressively.
+
+## GOV.UK Design Principles
+
+The layer above any component library, and the right default for public-sector
+service work:
+
+1. Start with user needs.
+2. Do less.
+3. Design with data.
+4. Do the hard work to make it simple.
+5. Iterate. Then iterate again.
+6. This is for everyone (accessibility is not optional - see the accessibility
+   references).
+7. Understand context.
+8. Build digital services, not websites.
+9. Be consistent, not uniform.
+10. Make things open: it makes things better.
+
+## Navigation
+
+- Answer on every page: **Where am I? Where can I go? Where is the home?**
+- Keep **persistent navigation** consistent across pages; the logo links home.
+- Show the user's location (highlighted section, **breadcrumbs**, a clear page
+  name).
+- Provide obvious **search** for anything non-trivial; many users navigate by
+  searching, not browsing.
+
+## Test it cheaply
+
+Krug's central practical claim: **a little usability testing, done often, beats
+a lot done late.** Watching a few real users attempt a task surfaces the big
+problems fast. When reviewing, flag the places a first-time user would pause and
+ask a question - those are the ones worth testing.
+
+## Further reading
+
+- Steve Krug, *Don't Make Me Think* and *Rocket Surgery Made Easy*.
+- Jakob Nielsen, "10 Usability Heuristics for User Interface Design" (Nielsen
+  Norman Group).
+- Don Norman, *The Design of Everyday Things*.
+- GOV.UK Design Principles - https://www.gov.uk/guidance/government-design-principles

--- a/src/claude/skills/ui-craft/references/visual-design.md
+++ b/src/claude/skills/ui-craft/references/visual-design.md
@@ -1,0 +1,111 @@
+# Accessible visual design
+
+The visual layer is mostly about Perceivable (the first POUR principle): can
+people see and distinguish the content, at their own text size and zoom?
+Grounded in WCAG 2.2 AA, with practical framing from the dxw accessibility
+manual and the DWP "dos and don'ts" posters.
+
+## Colour contrast
+
+Meet at least WCAG 2.2 AA:
+
+- **Body text**: 4.5:1 against its background.
+- **Large text** (18pt+, or 14pt+ bold): 3:1.
+- **UI components and meaningful graphics**: 3:1 against adjacent colours (e.g.
+  input borders, icons, chart segments).
+
+### On extremes
+
+Pure black on pure white (`#000` on `#fff`) can cause visual stress for some
+readers, particularly with dyslexia. But some users - for example with low
+vision - need maximum contrast. So this is a design consideration, not a rule:
+never drop below AA to soften things, and if you want a gentler default (say
+`#1a1a1a` on `#fff`), pair it with a high-contrast option rather than removing
+the choice.
+
+### Text over images
+
+Avoid text directly over photos or textured backgrounds. If unavoidable, put a
+solid or semi-transparent panel behind the text so the contrast ratio is
+actually met across the whole image.
+
+### Tools
+
+- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) -
+  pass/fail against AA and AAA.
+- [Who Can Use](https://www.whocanuse.com/) - shows a combination through
+  different vision conditions.
+- [Accessible Colors](https://accessible-colors.com/) - suggests nearby passing
+  colours.
+
+## Do not rely on colour alone
+
+People with colour-vision deficiencies may not distinguish colours, so colour
+must never be the only carrier of meaning (WCAG 1.4.1). Add a second cue:
+
+- Text labels or icons on status indicators and chart series.
+- Underlines on links, not just a colour change.
+- Text (and position/icon) alongside error and success states (see `forms.md`).
+
+## Typography
+
+### Body text
+
+- Minimum 16px (1rem) body text.
+- Use relative units (`rem`, `em`, `%`) so users can resize; never fix text in
+  `px` in a way that blocks browser text scaling.
+- Line height around 1.5 for body copy.
+- Keep line length readable - roughly 45-75 characters.
+
+### Headings
+
+- A clear visual hierarchy with distinct steps between levels (visual size is
+  separate from semantic level - see `accessible-code.md`).
+- Headings larger and bolder than body text, styled consistently throughout.
+
+### Font choice
+
+- Prefer widely available, plainly legible typefaces for body text; avoid
+  decorative or highly stylised fonts for anything users must read.
+- Check the font renders clearly at small sizes and survives browser text
+  resizing.
+
+## Zoom, reflow, and spacing (Perceivable / Operable)
+
+- **Reflow** (WCAG 1.4.10): content must work at 400% zoom (roughly a 320px-wide
+  viewport) without loss of information or two-dimensional scrolling. Use
+  responsive, relative layouts, not fixed pixel widths.
+- **Text spacing** (WCAG 1.4.12): the layout must not break when users override
+  line height, paragraph, letter, and word spacing. Avoid fixed-height
+  containers that clip text.
+- **Reduced motion**: honour `prefers-reduced-motion` for parallax, autoplay,
+  and large transitions (implementation in `accessible-code.md`).
+- **Target size** (WCAG 2.2, 2.5.8): give interactive targets enough size and
+  spacing (24×24 CSS px or equivalent) - a layout concern as much as a code
+  one.
+
+## The DWP "dos and don'ts" posters
+
+A memorable practitioner summary (UK Home Office / DWP accessibility posters),
+by broad user group:
+
+- **Low vision**: use good contrast and a readable size; do not use low contrast
+  or fix small font sizes.
+- **D/deaf or hard of hearing**: caption and transcribe media, write plainly; do
+  not bury information only in audio.
+- **Dyslexia**: left-align text, break content into chunks, support text
+  scaling; do not use dense blocks of text or justify text.
+- **Motor difficulties**: large clickable targets, generous spacing, keyboard
+  support; do not demand precision or bunch controls together.
+- **Autism / cognitive load**: simple consistent layouts, plain language; do not
+  overload with colour, motion, or figures of speech.
+- **Screen reader users**: semantic structure, real labels, descriptive links;
+  do not rely on shape, colour, or spatial words like "click the box on the
+  right".
+
+## Further reading
+
+- dxw accessibility manual - designing accessible services - https://accessibility.dxw.com/interaction-design/
+- Home Office / DWP accessibility posters - https://ukhomeoffice.github.io/accessibility-posters/
+- Inclusive Design Principles - https://inclusivedesignprinciples.org/
+- Microsoft Inclusive Design Toolkit - https://www.microsoft.com/design/inclusive/


### PR DESCRIPTION
This adds two Claude Code skills, symlinked into `~/.claude/skills` via dotbot. `code-craft` covers reviewing, refactoring, structuring, and testing code, drawing on Sandi Metz, Martin Fowler, the Gang of Four, general engineering principles, SOLID, connascence, performance, and reliability. `ui-craft` covers building and reviewing user interfaces, combining usability (Krug, Nielsen, Norman) with accessibility (WCAG 2.2, the GOV.UK Design System, and the dxw accessibility manual). Both keep a lean dispatcher `SKILL.md` and load per-topic references on demand.

It also extracts a set of general working preferences into the global `CLAUDE.md`: reading surrounding code before changes, considering ADRs for significant decisions, keeping the test suite green, small atomic commits, `--force-with-lease` over `--force`, checking that a branch's commits are atomic and well ordered before pushing, an OWASP and secrets check, screenshots for user-facing PRs, an added rule against citing a particular author, and treating notable design decisions as learning opportunities. A final preference records how commit subjects for these preference changes should be phrased.